### PR TITLE
Parallel order test

### DIFF
--- a/test/parallel-order/README
+++ b/test/parallel-order/README
@@ -1,0 +1,1 @@
+Check that tests not only run in parallel but also output their own results

--- a/test/parallel-order/index.js
+++ b/test/parallel-order/index.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+var assert = require('assert');
+var path = require('path');
+var exec = require('child_process').exec;
+var libExecutable = path.resolve(__dirname, '../../bin/mocha-parallel-tests');
+var start = Date.now();
+
+exec(libExecutable + ' -R json --timeout 60000 --slow 30000 test/parallel-order/tests', {
+    cwd: path.resolve(__dirname, '../../')
+}, function (err, stderr) {
+    var diffTime = Date.now() - start;
+    assert.equal(Math.round(diffTime / 1000) < 11, true, 'Tests should run in parallel');
+
+    if (err) {
+        console.error(err);
+        process.exit(1);
+    }
+
+    var jsonReporterOutput = stderr.toString();
+
+    try {
+        jsonReporterOutput = JSON.parse(jsonReporterOutput);
+    } catch (ex) {
+        console.error('Native JSON reporter output is not valid JSON: ' + jsonReporterOutput);
+        process.exit(1);
+    }
+
+    assert.equal(typeof jsonReporterOutput.stats, 'object', 'Reporter should contain stats object');
+    assert.equal(jsonReporterOutput.stats.suites, 3, 'Reporter should contain information about 3 suites');
+    assert.equal(jsonReporterOutput.stats.tests, 4, 'Reporter should contain information about all run tests');
+    assert.equal(jsonReporterOutput.stats.passes, 3, 'Reporter should contain information about all passes');
+    assert.equal(jsonReporterOutput.stats.pending, 0, 'Reporter should contain information about all pendings');
+    assert.equal(jsonReporterOutput.stats.failures, 1, 'Reporter should contain information about all failures');
+
+    // common structure
+    assert.equal(Array.isArray(jsonReporterOutput.tests), true, 'Reporter should contain tests array');
+    assert.equal(Array.isArray(jsonReporterOutput.pending), true, 'Reporter should contain pendings array');
+    assert.equal(Array.isArray(jsonReporterOutput.passes), true, 'Reporter should contain passes array');
+
+    // first output should be from parallel1.js
+    assert.equal(jsonReporterOutput.tests[0].fullTitle, 'Test suite #1 should end in 3 seconds', 'First output should be from parallel1.js')
+    assert.equal(jsonReporterOutput.tests[0].duration >= 3000 && jsonReporterOutput.tests[0].duration < 4000, true, 'parallel1.js suite should end in 3 seconds');
+
+    // second output should be from parallel3.js
+    // because parallel1.js ended and parallel2.js is still running
+    assert.equal(jsonReporterOutput.tests[1].fullTitle, 'Test suite #3 should end in 3 seconds', 'Second output should be from parallel3.js')
+    assert.equal(jsonReporterOutput.tests[1].duration >= 3000 && jsonReporterOutput.tests[1].duration < 4000, true, 'parallel3.js suite should end in 3 seconds');
+
+    // and the last output should be from parallel2.js
+    assert.equal(jsonReporterOutput.tests[2].fullTitle, 'Test suite #2 should end in 5 seconds', 'Last output should be from parallel2.js')
+    assert.equal(jsonReporterOutput.tests[2].duration >= 5000 && jsonReporterOutput.tests[2].duration < 6000, true, 'parallel2.js suite should end in 5 seconds');
+    assert.equal(jsonReporterOutput.tests[3].fullTitle, 'Test suite #2 should fail', 'parallel2.js second test should fail');
+    assert(jsonReporterOutput.tests[3].err, true, 'parallel2.js second test should fail');
+
+    // check failure
+    assert.equal(Array.isArray(jsonReporterOutput.failures), true, 'Reporter should contain failures array');
+    assert.equal(jsonReporterOutput.failures.length, 1, 'Reporter should contain one error');
+    assert.equal(jsonReporterOutput.failures[0].fullTitle, 'Test suite #2 should fail');
+    assert.equal(jsonReporterOutput.failures[0].err.message, 'some error');
+});

--- a/test/parallel-order/tests/parallel1.js
+++ b/test/parallel-order/tests/parallel1.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('Test suite #1', function () {
+    it('should end in 3 seconds', function (done) {
+        setTimeout(done, 3000);
+    });
+});

--- a/test/parallel-order/tests/parallel2.js
+++ b/test/parallel-order/tests/parallel2.js
@@ -1,0 +1,11 @@
+'use strict';
+
+describe('Test suite #2', function () {
+    it('should end in 5 seconds', function (done) {
+        setTimeout(done, 5000);
+    });
+
+    it('should fail', function (done) {
+        done(new Error('some error'));
+    });
+});

--- a/test/parallel-order/tests/parallel3.js
+++ b/test/parallel-order/tests/parallel3.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('Test suite #3', function () {
+    it('should end in 3 seconds', function (done) {
+        setTimeout(done, 3000);
+    });
+});


### PR DESCRIPTION
Один из самых важных тестов, половина шестого теста из KINOFRONT-6045.
JSON-репортер mocha-parallel-tests должен отдавать тот же ответ, что и mocha-вский, только быстрее (из-за параллельного запуска). Но видно, что ответ у каждого теста свой и в ответе невалидный JSON.

`test/parallel-order/index.js` - так видно, что все неок
`./node_modules/.bin/mocha -R json --timeout 60000 --slow 30000 test/parallel-order/tests` - а так примерно должно выглядеть то, что мы хотим получить. Это же я проверяю в тесте.

Именно из-за этого виден странный ответ в #7 - тесты не знают друг о друге, а мы должны как раз им дать друг о друге знать и тогда в конце было бы `3 tests passed`.

Предлагаю этот тест вмержить, а код править уже с ним. То есть поправить код - прогнать тест. И так далее.