### PR TITLE
[WIP] parallel-order test fixes

### DIFF
--- a/test/parallel-order/index.js
+++ b/test/parallel-order/index.js
@@ -33,6 +33,15 @@ exec(libExecutable + ' -R json --timeout 60000 --slow 30000 test/parallel-order/
     assert.equal(jsonReporterOutput.stats.pending, 0, 'Reporter should contain information about all pendings');
     assert.equal(jsonReporterOutput.stats.failures, 1, 'Reporter should contain information about all failures');
 
+    // check time diff
+    var startDate = new Date(jsonReporterOutput.stats.start);
+    var endDate = new Date(jsonReporterOutput.stats.end);
+    var diffMs = endDate - startDate;
+
+    assert(startDate.getTime(), 'Start date is invalid');
+    assert(endDate.getTime(), 'End date is invalid');
+    assert.strictEqual(diffMs >= 8000, true, 'Diff between end and start dates is too small');
+
     // common structure
     assert.equal(Array.isArray(jsonReporterOutput.tests), true, 'Reporter should contain tests array');
     assert.equal(Array.isArray(jsonReporterOutput.pending), true, 'Reporter should contain pendings array');
@@ -41,6 +50,8 @@ exec(libExecutable + ' -R json --timeout 60000 --slow 30000 test/parallel-order/
     // first output should be from parallel1.js
     assert.equal(jsonReporterOutput.tests[0].fullTitle, 'Test suite #1 should end in 3 seconds', 'First output should be from parallel1.js')
     assert.equal(jsonReporterOutput.tests[0].duration >= 3000 && jsonReporterOutput.tests[0].duration < 4000, true, 'parallel1.js suite should end in 3 seconds');
+
+    console.log(jsonReporterOutput)
 
     // second output should be from parallel3.js
     // because parallel1.js ended and parallel2.js is still running

--- a/test/parallel-order/index.js
+++ b/test/parallel-order/index.js
@@ -51,8 +51,6 @@ exec(libExecutable + ' -R json --timeout 60000 --slow 30000 test/parallel-order/
     assert.equal(jsonReporterOutput.tests[0].fullTitle, 'Test suite #1 should end in 3 seconds', 'First output should be from parallel1.js')
     assert.equal(jsonReporterOutput.tests[0].duration >= 3000 && jsonReporterOutput.tests[0].duration < 4000, true, 'parallel1.js suite should end in 3 seconds');
 
-    console.log(jsonReporterOutput)
-
     // second output should be from parallel3.js
     // because parallel1.js ended and parallel2.js is still running
     assert.equal(jsonReporterOutput.tests[1].fullTitle, 'Test suite #3 should end in 3 seconds', 'Second output should be from parallel3.js')


### PR DESCRIPTION
Difference between start and end should be at least 8 seconds. Now they are the same:
```
{ stats: 
   { suites: 3,
     tests: 4,
     passes: 3,
     pending: 0,
     failures: 1,
     start: '2015-12-14T19:40:47.159Z',
     end: '2015-12-14T19:40:47.159Z',
```