### PR TITLE
Disabled EventEmitter memory leak warning

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -20,6 +20,7 @@ var originalWrites = {};
 var interceptedData = {};
 
 var stdStreamsEmitter = new events.EventEmitter;
+stdStreamsEmitter.setMaxListeners(0); // Disable EventEmitter memory leak warning
 
 function getSuiteFile(executionStack) {
     var stackFiles = executionStack.split('\n').reduce(function (stackFiles, chunk) {


### PR DESCRIPTION
Fix for 

```
(node) warning: possible EventEmitter memory leak detected. 11 fail listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at EventEmitter.addListener (events.js:179:15)
    at new MochaParallelTests (/home/nbasov/Documents/ssp-api/node_modules/mocha-parallel-tests/lib/reporter.js:73:35)
    at Mocha.run (/home/nbasov/Documents/ssp-api/node_modules/mocha-parallel-tests/node_modules/mocha/lib/mocha.js:474:18)
    at /home/nbasov/Documents/ssp-api/node_modules/mocha-parallel-tests/lib/watcher.js:102:32
    at runTests (/home/nbasov/Documents/ssp-api/node_modules/mocha-parallel-tests/lib/watcher.js:165:11)
    at Immediate.onEnd [as _onImmediate] (/home/nbasov/Documents/ssp-api/node_modules/mocha-parallel-tests/lib/watcher.js:110:21)
    at processImmediate [as _immediateCallback] (timers.js:358:17)
```

node: v0.12.4