### PR TITLE
Force process.exit for async tests

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -63,6 +63,7 @@ function MochaParallelTests(runner, options) {
     var Base = Mocha.reporters.Base;
     var testFile;
     var relativeFilePath;
+    var hasFailedTests = false;
 
     if (runner.suite.suites.length) {
         testFile = runner.suite.suites[0].file;
@@ -119,6 +120,10 @@ function MochaParallelTests(runner, options) {
 
     runner.on('fail', function () {
         storeEventData('fail', arguments);
+    });
+
+    runner.on('retry fail', function () {
+        hasFailedTests = true;
     });
 
     runner.on('test end', function(test) {
@@ -194,6 +199,8 @@ function MochaParallelTests(runner, options) {
 
         if (testsFinished === options.testsLength) {
             customRunner.end();
+            // Force exit from async tests
+            process.exit(hasFailedTests ? 1 : 0);
         }
     });
 }

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -146,6 +146,9 @@ function runTests() {
 
                     // re-run pending tests
                     runTests();
+                } else {
+                    // Emit event to handle force exit from async tests
+                    stdStreamsEmitter.emit('retry fail', test.file);
                 }
             }
 


### PR DESCRIPTION
Now exit properly after async tests finish