### PR TITLE
Support mocha@3, use peerDependencies for mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Also `mocha-parallel-tests` supports its own `--max-parallel` (max parallel runn
 
 ## Installation
 
-`npm install --save mocha-parallel-tests`
+`npm install --save-dev mocha-parallel-tests mocha`
+
+Starting from 0.6.0 `mocha-parallel-tests` adds mocha as a [peerDependency](https://nodejs.org/en/blog/npm/peer-dependencies/) so you should specify what `mocha` version you want to run tests with. Currently 2.3.x, 2.4.x and 3.0.x mocha versions are supported.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-parallel-tests",
-  "version": "0.5.5",
+  "version": "0.6.0-beta.1",
   "homepage": "https://github.com/mmotkina/mocha-parallel-tests",
   "description": "Run mocha tests in parallel",
   "main": "./dist/build.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   ],
   "dependencies": {
     "debug": "2.2.0",
-    "mocha": "2.4.5",
     "yargs": "3.30.0"
   },
   "repository": {
@@ -41,6 +40,9 @@
   "license": "MIT",
   "engines": {
     "node": ">=4"
+  },
+  "peerDependencies": {
+    "mocha": ">= 2.3.x || 3.0.x"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",


### PR DESCRIPTION
@mmotkina @ixax @gkrasulya ребята, посмотрите плз. Это достаточно важное изменение без обратной совместимости. Про peerDependencies: https://nodejs.org/en/blog/npm/peer-dependencies/

Позволит запускать mocha-parallel-tests с любой версией mocha, в том числе 3.0.0, которая вышла на прошлой неделе (но в ней нет ни одной новой фичи, да)